### PR TITLE
Add dashboard and router

### DIFF
--- a/app/javascript/hello_angular/app/app-routing.module.ts
+++ b/app/javascript/hello_angular/app/app-routing.module.ts
@@ -2,11 +2,13 @@ import { NgModule }              from '@angular/core';
 import { RouterModule, Routes }  from '@angular/router';
 
 import { DashboardComponent }     from '../dashboard/dashboard.component';
+import { HomeComponent }     from '../home/home.component';
 import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
 
 const appRoutes: Routes = [
+  { path: 'home',        component: HomeComponent },
   { path: 'dashboard',        component: DashboardComponent },
-  //{ path: '',   redirectTo: '/', pathMatch: 'full' },
+  { path: '',   redirectTo: '/home', pathMatch: 'full' },
   { path: '**', component: PageNotFoundComponent }
 ];
 

--- a/app/javascript/hello_angular/app/app-routing.module.ts
+++ b/app/javascript/hello_angular/app/app-routing.module.ts
@@ -1,0 +1,27 @@
+import { NgModule }              from '@angular/core';
+import { RouterModule, Routes }  from '@angular/router';
+
+import { DashboardComponent }     from '../dashboard/dashboard.component';
+import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
+
+const appRoutes: Routes = [
+  { path: 'dashboard',        component: DashboardComponent },
+  //{ path: '',   redirectTo: '/', pathMatch: 'full' },
+  { path: '**', component: PageNotFoundComponent }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forRoot(
+      appRoutes,
+      {
+        useHash: true,
+        enableTracing: true // <-- debugging purposes only
+      }
+    )
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class AppRoutingModule {}

--- a/app/javascript/hello_angular/app/app.component.html
+++ b/app/javascript/hello_angular/app/app.component.html
@@ -2,9 +2,8 @@
 <br>
 <h2>Angular Router</h2>
 <nav>
+  <a routerLink="/home" routerLinkActive="active">Home</a>
   <a routerLink="/dashboard" routerLinkActive="active">Dashboard</a>
   <a routerLink="/pagenotfound" routerLinkActive="active">Page Not Found</a>
 </nav>
 <router-outlet></router-outlet>
-<app-signup-form></app-signup-form>
-<app-login-form></app-login-form>

--- a/app/javascript/hello_angular/app/app.component.html
+++ b/app/javascript/hello_angular/app/app.component.html
@@ -1,4 +1,10 @@
 <h1>This is the app.component.html file.</h1>
 <br>
+<h2>Angular Router</h2>
+<nav>
+  <a routerLink="/dashboard" routerLinkActive="active">Dashboard</a>
+  <a routerLink="/pagenotfound" routerLinkActive="active">Page Not Found</a>
+</nav>
+<router-outlet></router-outlet>
 <app-signup-form></app-signup-form>
 <app-login-form></app-login-form>

--- a/app/javascript/hello_angular/app/app.module.ts
+++ b/app/javascript/hello_angular/app/app.module.ts
@@ -7,6 +7,7 @@ import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 
 import { DashboardComponent } from '../dashboard/dashboard.component';
+import { HomeComponent } from '../home/home.component';
 import { LoginFormComponent } from '../login-form/login-form.component';
 import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
 import { SignupFormComponent } from '../signup-form/signup-form.component';
@@ -18,6 +19,7 @@ import { AuthService } from '../_services/auth.service';
   declarations: [
     AppComponent,
     DashboardComponent,
+    HomeComponent,
     LoginFormComponent,
     PageNotFoundComponent,
     SignupFormComponent

--- a/app/javascript/hello_angular/app/app.module.ts
+++ b/app/javascript/hello_angular/app/app.module.ts
@@ -4,21 +4,29 @@ import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
+import { AppRoutingModule } from './app-routing.module';
+
+import { DashboardComponent } from '../dashboard/dashboard.component';
 import { LoginFormComponent } from '../login-form/login-form.component';
+import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
 import { SignupFormComponent } from '../signup-form/signup-form.component';
 
 import { httpInterceptorProviders } from '../http-interceptors/index';
 import { AuthService } from '../_services/auth.service';
+
 @NgModule({
   declarations: [
     AppComponent,
+    DashboardComponent,
     LoginFormComponent,
+    PageNotFoundComponent,
     SignupFormComponent
   ],
   imports: [
     BrowserModule,
     FormsModule,
-    HttpClientModule
+    HttpClientModule,
+    AppRoutingModule
   ],
   providers: [
     httpInterceptorProviders,

--- a/app/javascript/hello_angular/dashboard/dashboard.component.html
+++ b/app/javascript/hello_angular/dashboard/dashboard.component.html
@@ -1,0 +1,3 @@
+<div class="dashboard">
+  <h1>Dashboard Page</h1>
+</div>

--- a/app/javascript/hello_angular/dashboard/dashboard.component.html
+++ b/app/javascript/hello_angular/dashboard/dashboard.component.html
@@ -1,3 +1,4 @@
 <div class="dashboard">
   <h1>Dashboard Page</h1>
+  <p>Looks like nobody needs anything yet.</p>
 </div>

--- a/app/javascript/hello_angular/dashboard/dashboard.component.ts
+++ b/app/javascript/hello_angular/dashboard/dashboard.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import templateString from './dashboard.component.html';
+
+@Component({
+  template: templateString,
+  providers: []
+})
+export class DashboardComponent{
+
+  constructor() {}
+
+}

--- a/app/javascript/hello_angular/home/home.component.html
+++ b/app/javascript/hello_angular/home/home.component.html
@@ -1,0 +1,6 @@
+<div class="home">
+  <h1>HomePage</h1>
+  <p>It's a bit rough right now, we're still building up the app, so pardon the mess.</p>
+  <app-signup-form></app-signup-form>
+  <app-login-form></app-login-form>
+</div>

--- a/app/javascript/hello_angular/home/home.component.ts
+++ b/app/javascript/hello_angular/home/home.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import templateString from './home.component.html';
+
+@Component({
+  template: templateString,
+  providers: []
+})
+export class HomeComponent {
+
+  constructor() {}
+
+}

--- a/app/javascript/hello_angular/login-form/login-form.component.ts
+++ b/app/javascript/hello_angular/login-form/login-form.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router }  from '@angular/router';
 import templateString from './login-form.component.html';
 
 import { User } from '../_models/user';
@@ -15,7 +16,11 @@ export class LoginFormComponent {
   submitted = false;
   loginFail = false;
 
-  constructor(private loginFormService: LoginFormService, private authService: AuthService) {}
+  constructor(
+    private router: Router,
+    private loginFormService: LoginFormService,
+    private authService: AuthService
+  ) {}
 
   onSubmit() {
     this.submitted = true;
@@ -28,6 +33,7 @@ export class LoginFormComponent {
         next: resp => {
           this.authService.setAuthorizationToken(resp.auth_token);
           this.loginFail = false;
+          this.router.navigate(['/dashboard']);
         },
         error: err => {
           this.loginFail = true;

--- a/app/javascript/hello_angular/page-not-found/page-not-found.component.html
+++ b/app/javascript/hello_angular/page-not-found/page-not-found.component.html
@@ -1,0 +1,3 @@
+<div class="container">
+  <h1>Page Not Found</h1>
+</div>

--- a/app/javascript/hello_angular/page-not-found/page-not-found.component.ts
+++ b/app/javascript/hello_angular/page-not-found/page-not-found.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import templateString from './page-not-found.component.html';
+
+@Component({
+  template: templateString,
+  providers: []
+})
+export class PageNotFoundComponent{
+
+  constructor() {}
+
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <base href="/">
     <title>Throwaway</title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
-
   <body>
     <%= yield %>
   </body>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@angular/forms": "^5.2.10",
     "@angular/platform-browser": "^5.2.9",
     "@angular/platform-browser-dynamic": "^5.2.9",
+    "@angular/router": "^5.2.10",
     "@rails/webpacker": "^3.3.1",
     "@types/jest": "^22.2.3",
     "core-js": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,12 @@
   dependencies:
     tslib "^1.7.1"
 
+"@angular/router@^5.2.10":
+  version "5.2.10"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-5.2.10.tgz#cb36c32de0a233a9b49789e11ca0f96c5304f25a"
+  dependencies:
+    tslib "^1.7.1"
+
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz#a9c83233fa7cd06b39dc77adbb908616ff4f1962"


### PR DESCRIPTION
Added the angular routing module.
Ended up using the HashLocationStrategy, instead of the default HTML5 PathLocationStrategy, because I couldn't figure out a way to set things up such that my app knows when to use Rails routing, or when to use Angular routing. 

With the HashLocationStrategy, it is obvious what routes what.

The signup and login forms were moved under a new Home component, so I could route to the Dashboard after logging in.